### PR TITLE
Update bounds on crypto-random and aeson

### DIFF
--- a/jose.cabal
+++ b/jose.cabal
@@ -44,7 +44,7 @@ library
     Crypto.JWT
 
   other-modules:
-    Crypto.JOSE.JWA.JWK
+    Crypto.JOSE.JWA.JKW
     Crypto.JOSE.JWA.JWS
     Crypto.JOSE.JWA.JWE
     Crypto.JOSE.JWA.JWE.Alg
@@ -59,10 +59,10 @@ library
     , byteable == 0.1.*
     , crypto-pubkey >= 0.2.3
     , crypto-pubkey-types >= 0.3.2
-    , crypto-random == 0.0.7.*
+    , crypto-random >= 0.0.7 && < 0.0.9
     , cryptohash == 0.11.*
     , template-haskell >= 2.4
-    , aeson == 0.7.*
+    , aeson >= 0.7.* && < 0.9
     , unordered-containers == 0.2.*
     , bytestring == 0.10.*
     , text == 1.1.*


### PR DESCRIPTION
NixOS by default uses crypto-random 0.0.8 and aeson 0.8.0.0.  This seems to work fine.
