### PR TITLE
JWT: implement "nbf" and "exp" processing

### DIFF
--- a/jose.cabal
+++ b/jose.cabal
@@ -66,6 +66,7 @@ library
     , cryptonite >= 0.7
     , lens >= 4.3
     , memory >= 0.7
+    , monad-time >= 0.1
     , mtl >= 2
     , template-haskell >= 2.4
     , safe >= 0.3
@@ -115,6 +116,7 @@ test-suite tests
     , cryptonite
     , lens
     , memory
+    , monad-time
     , mtl
     , template-haskell
     , safe

--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -259,7 +259,7 @@ validateNbfClaim
   -> ClaimsSet
   -> m Bool
 validateNbfClaim _ (ClaimsSet _ _ _ _ (Just n) _ _ _) =
-  (n <) . NumericDate <$> currentTime
+  (n <=) . NumericDate <$> currentTime
 validateNbfClaim _ _ = return True
 
 

--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -289,14 +289,17 @@ instance ToCompact JWT where
   toCompact = toCompact . jwtCrypto
 
 
--- | Validate a JWT as a JWS (JSON Web Signature).
+-- | Validate a JWT as a JWS (JSON Web Signature), then as a Claims
+-- Set.
 --
 validateJWSJWT
-  :: State ValidationSettings z
+  :: MonadTime m
+  => State ValidationSettings z
   -> JWK
   -> JWT
-  -> Bool
-validateJWSJWT conf k (JWT (JWTJWS jws) _) = verifyJWS conf k jws
+  -> m Bool
+validateJWSJWT conf k (JWT (JWTJWS jws) c) =
+  (verifyJWS conf k jws &&) <$> validateClaimsSet conf c
 
 -- | Create a JWT that is a JWS.
 --

--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -230,7 +230,9 @@ instance ToJSON ClaimsSet where
 
 
 -- | Validate the claims made by a ClaimsSet. Currently only inspects
--- the exp and nbf claims.
+-- the /exp/ and /nbf/ claims. N.B. These checks are also performed by
+-- 'validateJWSJWT', which also validates any signatures, so you
+-- shouldn’t need to use this directly in the normal course of things.
 --
 validateClaimsSet
   :: MonadTime m

--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -301,7 +301,10 @@ validateJWSJWT
   -> JWT
   -> m Bool
 validateJWSJWT conf k (JWT (JWTJWS jws) c) =
-  (verifyJWS conf k jws &&) <$> validateClaimsSet conf c
+  -- It is important, for security reasons, that the signature get
+  -- verified before the claims.
+  (&&) <$> pure (verifyJWS conf k jws)
+       <*> validateClaimsSet conf c
 
 -- | Create a JWT that is a JWS.
 --

--- a/test/JWT.hs
+++ b/test/JWT.hs
@@ -69,18 +69,23 @@ spec = do
     describe "when the current time is prior to the Expiration Time" $
       let
         now = utcTime "2010-01-01 00:00:00"
-        run = flip runReader now
       in
         it "can be validated" $
-          run (validateClaimsSet conf exampleClaimsSet) `shouldBe` True
+          runReader (validateClaimsSet conf exampleClaimsSet) now `shouldBe` True
+
+    describe "when the current time is exactly the Expiration Time" $
+      let
+        now = utcTime "2011-03-22 18:43:00"
+      in
+        it "cannot be validated" $
+          runReader (validateClaimsSet conf exampleClaimsSet) now `shouldBe` False
 
     describe "when the current time is after the Expiration Time" $
       let
         now = utcTime "2012-01-01 00:00:00"
-        run = flip runReader now
       in
         it "cannot be validated" $
-          run (validateClaimsSet conf exampleClaimsSet) `shouldBe` False
+          runReader (validateClaimsSet conf exampleClaimsSet) now `shouldBe` False
 
     describe "with a Not Before claim" $
       let
@@ -89,18 +94,23 @@ spec = do
         describe "when the current time is prior to the Not Before claim" $
           let
             now = utcTime "2015-01-01 00:00:00"
-            run = flip runReader now
           in
             it "cannot be validated" $
-              run (validateClaimsSet conf claimsSet) `shouldBe` False
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` False
+
+        describe "when the current time is exactly equal to the Not Before claim" $
+          let
+            now = utcTime "2016-07-05 17:37:22"
+          in
+            it "can be validated" $
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` True
 
         describe "when the current time is after the Not Before claim" $
           let
             now = utcTime "2017-01-01 00:00:00"
-            run = flip runReader now
           in
             it "can be validated" $
-              run (validateClaimsSet conf claimsSet) `shouldBe` True
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` True
 
     describe "with Expiration Time and Not Before claims" $
       let
@@ -110,24 +120,37 @@ spec = do
         describe "when the current time is prior to the Not Before claim" $
           let
             now = utcTime "2011-03-18 00:00:00"
-            run = flip runReader now
           in
             it "cannot be validated" $
-              run (validateClaimsSet conf claimsSet) `shouldBe` False
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` False
+
+        describe "when the current time is exactly equal to the Not Before claim" $
+          let
+            now = utcTime "2011-03-20 17:37:22"
+          in
+            it "can be validated" $
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` True
+
         describe "when the current time is between the Not Before and Expiration Time claims" $
           let
             now = utcTime "2011-03-21 18:00:00"
-            run = flip runReader now
           in
             it "can be validated" $
-              run (validateClaimsSet conf claimsSet) `shouldBe` True
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` True
+
+        describe "when the current time is exactly the Expiration Time" $
+          let
+            now = utcTime "2011-03-22 18:43:00"
+          in
+            it "cannot be validated" $
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` False
+
         describe "when the current time is after the Expiration Time claim" $
           let
             now = utcTime "2011-03-24 00:00:00"
-            run = flip runReader now
           in
             it "cannot be validated" $
-              run (validateClaimsSet conf claimsSet) `shouldBe` False
+              runReader (validateClaimsSet conf claimsSet) now `shouldBe` False
 
   describe "StringOrURI" $
     it "parses from JSON correctly" $ do
@@ -161,6 +184,7 @@ spec = do
           it "can be decoded and validated" $ do
             fmap jwtClaimsSet jwt `shouldBe` Right exampleClaimsSet
             fmap (run . validateJWSJWT conf k) jwt `shouldBe` Right True
+
       describe "when the current time is after the Expiration Time" $
         let
           now = utcTime "2012-01-01 00:00:00"


### PR DESCRIPTION
Mostly as discussed in #9 with the following exceptions:

  1. `validateClaimsSet` is exported from Crypto.JWT separately from `validateJWSJWT`, mostly for ease of testing. Doing so may lead some users to _only_ validate the claims, without realizing that they need to validate the signature as well. I added an additional warning to try to prevent this. 

  2. Prior to these commits, the signature of `validateJWSJWT` had been changed to use `ValidationsSettings` instead of `ValidationAlgorithms` and `ValidationPolicy`. I left it as it was, choosing to defer to the code over the discussion in #9. 

  3. I did not provide `validateJWSJWTWithTime`, as was discussed in #9. The implementation uses MonadTime, of which IO and any mtl stack terminating in IO are all instances, and (as demonstrated in the tests) it is straightforward to make `Reader UTCTime` an instance for testing purposes. I believe that this covers any use cases that would be served by `validateJWSJWTWithTime` without tempting unsophisticated users to perform unsafe IO. 