### PR TITLE
Remove overlapping instance for AsError.

### DIFF
--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -92,7 +92,7 @@ data JWTError
   deriving (Eq, Show)
 makeClassyPrisms ''JWTError
 
-instance AsJWTError e => AsError e where
+instance AsError JWTError where
   _Error = _JWSError
 
 


### PR DESCRIPTION
   Which otherwise makes Error unusable AsError.