### PR TITLE
Test Coverage Reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cabal.sandbox.config
 
 *.o
 *.hi
+
+TAGS

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ cabal.sandbox.config
 
 *.o
 *.hi
-
-TAGS

--- a/jose.cabal
+++ b/jose.cabal
@@ -19,7 +19,8 @@ homepage:            https://github.com/frasertweedale/hs-jose
 bug-reports:         https://github.com/frasertweedale/hs-jose/issues
 license:             Apache-2.0
 license-file:        LICENSE
-extra-source-files:  README.md
+extra-source-files:
+  README.md
 author:              Fraser Tweedale
 maintainer:          frase@frase.id.au
 copyright:           Copyright (C) 2013, 2014, 2015, 2016  Fraser Tweedale

--- a/jose.cabal
+++ b/jose.cabal
@@ -19,8 +19,7 @@ homepage:            https://github.com/frasertweedale/hs-jose
 bug-reports:         https://github.com/frasertweedale/hs-jose/issues
 license:             Apache-2.0
 license-file:        LICENSE
-extra-source-files:
-  README.md
+extra-source-files:  README.md
 author:              Fraser Tweedale
 maintainer:          frase@frase.id.au
 copyright:           Copyright (C) 2013, 2014, 2015, 2016  Fraser Tweedale
@@ -39,14 +38,14 @@ library
     Crypto.JOSE.JWS
     Crypto.JOSE.Types
     Crypto.JWT
-
-  other-modules:
     Crypto.JOSE.AESKW
     Crypto.JOSE.JWA.JWK
+    Crypto.JOSE.JWS.Internal
     Crypto.JOSE.JWA.JWS
     Crypto.JOSE.JWA.JWE
     Crypto.JOSE.JWA.JWE.Alg
-    Crypto.JOSE.JWS.Internal
+
+  other-modules:
     Crypto.JOSE.TH
     Crypto.JOSE.Types.Internal
     Crypto.JOSE.Types.Orphans
@@ -91,7 +90,7 @@ source-repository head
 
 test-suite tests
   type:           exitcode-stdio-1.0
-  hs-source-dirs: src, test
+  hs-source-dirs: test
   main-is:        Test.hs
   other-modules:
     AESKW
@@ -122,6 +121,8 @@ test-suite tests
     , network-uri
     , vector
     , x509
+
+    , jose
 
     , tasty
     , tasty-hspec


### PR DESCRIPTION
- update tests to depend on the library itself so that stack is able to generate test coverage report.
- `stack test --coverage` indicate that tests shall depend on library itself rather `src` directory so that it's able to create coverage report.
- not sure why you did not public some modules which used by tests but if there are some good reason, this pr could probably be disregarded.

Thanks!