### PR TITLE
Relax verification of JWSs signed with too short keys

### DIFF
--- a/jose.cabal
+++ b/jose.cabal
@@ -1,5 +1,5 @@
 name:                jose
-version:             0.6.0.1
+version:             0.6.0.4
 synopsis:
   Javascript Object Signing and Encryption and JSON Web Token library
 description:

--- a/src/Crypto/JOSE/JWA/JWK.hs
+++ b/src/Crypto/JOSE/JWA/JWK.hs
@@ -431,9 +431,7 @@ signOct
   -> B.ByteString
   -> m B.ByteString
 signOct h (OctKeyParameters (Types.Base64Octets k)) m =
-  if B.length k < hashDigestSize h
-  then throwError (review _KeySizeTooSmall ())
-  else pure $ B.pack $ BA.unpack (hmac k m :: HMAC h)
+  pure $ B.pack $ BA.unpack (hmac k m :: HMAC h)
 
 
 -- "OKP" (CFRG Octet Key Pair) keys (RFC 8037)

--- a/test/JWS.hs
+++ b/test/JWS.hs
@@ -285,16 +285,17 @@ jwtDotIOExample = describe "JWT from jwt.io using HMAC SHA-256" $ do
 shortKey :: Spec
 shortKey = describe "JWS using HMAC SHA-256 with a short key" $ do
   it "decodes the example to the correct value" $ do
-    jws ^? _Right . signatures . signature `shouldBe` Just mac
+    jws ^? _Right . signatures . signature
+      `shouldBe` (Just mac :: Maybe BS.ByteString)
     jws ^? _Right . signatures . header `shouldBe` Just h
 
   it "serialises the decoded JWS back to the original data" $
     fmap encodeCompact jws `shouldBe` Right compactJWS
 
-  it "computes the HMAC correctly" $
+  it "complains when signing" $
     fst (withDRG drg $
       runExceptT (sign alg (jwk ^. jwkMaterial) (signingInput' ^. recons)))
-      `shouldBe` (Right mac :: Either Error BS.ByteString)
+      `shouldBe` (Left KeySizeTooSmall)
 
   it "validates the JWS correctly" $
     (jws >>= verifyJWS defaultValidationSettings jwk)


### PR DESCRIPTION
We had the misfortune of interacting with a third-party signing their JWT:s with too short keys.
The added `signOct'` function does not perform the key length check and using it (instead of `signOct`) during verification resolves this issue.

In a perfect world this would not be needed. Do you agree with this pragmatic change? Or do you prefer adding a `verify'`?