### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/jose.cabal
+++ b/jose.cabal
@@ -47,8 +47,10 @@ common common
     , bytestring == 0.10.*
     , lens >= 4.16
     , mtl >= 2
-    , semigroups >= 0.15
     , text >= 1.1
+  if impl(ghc < 8.0)
+    build-depends:
+      semigroups >= 0.15
 
 library
   import: common


### PR DESCRIPTION
They are not needed on newer GHC.