### PR TITLE
Prevent expensive bytestring conversions

### DIFF
--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -541,7 +541,7 @@ verifyClaims conf k jws =
   -- verified before the claims.
   verifyJWSWithPayload f conf k jws >>= validateClaimsSet conf
   where
-    f = either (throwing _JWTClaimsSetDecodeError) pure . eitherDecode
+    f = either (throwing _JWTClaimsSetDecodeError) pure . eitherDecodeStrict
 
 
 -- | Cryptographically verify a JWS JWT, then validate the


### PR DESCRIPTION
Previously it was possible for JWS verification to take an incredibly long time to complete, see https://github.com/tweag/haskell-fido2/tree/a25308a07551ccd86af47774a74dbdf989454d51

This is seemingly caused by a conversion between different byte array representations, which https://hackage.haskell.org/package/concise seems to struggle with for some reason.

This commit fixes this by not doing _any_ implicit conversion between byte array representations, making `verifyJWS` return a (strict) `ByteString` directly, which is how the payload is represented underneath.