### PR TITLE
Require tasty-hedgehog >= 1.2

### DIFF
--- a/jose.cabal
+++ b/jose.cabal
@@ -121,7 +121,7 @@ test-suite tests
     , jose
 
     , tasty
-    , tasty-hedgehog
+    , tasty-hedgehog >= 1.2
     , tasty-hspec >= 1.0
     , hedgehog
     , hspec


### PR DESCRIPTION
I am getting the following error when building with an older tasty-hedgehog:
```
jose> test/Properties.hs:49:50: error:
jose>     Variable not in scope:
jose>       testPropertyNamed :: t0 -> t1 -> Property -> TestTree
jose>    |
jose> 49 |   , let n = "gen, sign with best alg, verify" in testPropertyNamed n n prop_bestJWSAlg
jose>    |                                                  ^^^^^^^^^^^^^^^^^
jose> [7 of 8] Compiling Types            ( test/Types.hs, dist/build/tests/tests-tmp/Types.o )
error: builder for '/nix/store/003qmk5cy3bnl5klnapbiapbyndry4ln-jose-0.10.drv' failed with exit code 1
```