### PR TITLE
Compact JWE decode and RSA-OAEP decrypt

### DIFF
--- a/src/Crypto/JOSE/Error.hs
+++ b/src/Crypto/JOSE/Error.hs
@@ -121,6 +121,7 @@ data Error
   | JWSNoSignatures
   -- ^ 'AllValidated' policy active, and there were no signatures on object
   --   that matched the allowed algorithms
+  | JWEIntegrityFailed
   deriving (Eq, Show)
 makeClassyPrisms ''Error
 

--- a/src/Crypto/JOSE/JWA/JWK.hs
+++ b/src/Crypto/JOSE/JWA/JWK.hs
@@ -47,6 +47,7 @@ module Crypto.JOSE.JWA.JWK (
   , toRSAPublicKeyParameters
   , rsaE
   , rsaN
+  , rsaPrivateKey
   , rsaPrivateKeyParameters
   , rsaPublicKey
   , genRSA


### PR DESCRIPTION
I needed JWE handling for our project. This adds decode from compact form, a flattened/generic split to JWE like JWS does and a decrypt function, along with a convenience function that turns it into compact JWS in one go. It's not a full implementation yet, obviously, but enough to cover our use case.

~The integrity check was still failing in my testing. I'm not sure if it's applying hashing correctly. Other than that the decrypt worked in my testing. I copied the hashing from the encrypt code that was already implemented but seeing how it got the keys in the wrong order I suspect it's not that tested either. (MAC key is first, see https://datatracker.ietf.org/doc/html/rfc7518#section-5.2.2.1). But since there's no implementation for this part as of yet either case I'm submitting the pull request regardless.~

Addendum 2023-12-01: I had a second look at the tag check code and got it working. While RFC 7516 allows having an empty AAD, looks like the way it is used in the wild is that the protected header is used as a part of it, even if the AAD would otherwise be empty, like with compact JWE representation.

This needs access to the private key so I exported it from `Crypto.JOSE.JWA.JWK`. That may or may not be a concern.