### PR TITLE
use crypton instead

### DIFF
--- a/jose.cabal
+++ b/jose.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                jose
-version:             0.10
+version:             0.11
 synopsis:
   JSON Object Signing and Encryption (JOSE) and JSON Web Token (JWT) library
 description:
@@ -111,14 +111,14 @@ library
     , base64-bytestring >= 1.2.1.0 && < 1.3
     , concise >= 0.1
     , containers >= 0.5
-    , cryptonite >= 0.24
+    , crypton >= 0.33
     , memory >= 0.7
     , monad-time >= 0.3
     , template-haskell >= 2.11
     , text >= 1.1
     , time >= 1.5
     , network-uri >= 2.6
-    , x509 >= 1.4
+    , crypton-x509 >= 1.7.6
 
   hs-source-dirs: src
 
@@ -144,10 +144,10 @@ test-suite tests
     , aeson
     , base64-bytestring
     , containers
-    , cryptonite
+    , crypton
     , time
     , network-uri
-    , x509
+    , crypton-x509
     , pem
 
     , concise


### PR DESCRIPTION
Basically the exact same PR as this one - https://github.com/frasertweedale/hs-jose/pull/115/files - but bumps the required version of crypton because it is available now!

Just curious to see if this will pass all the builds.