### PR TITLE
improve header protection ergonomics (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Version NEXT
 
+- Changed the header protection data types for better ergonomics
+  ([#125](https://github.com/frasertweedale/hs-jose/issues/125)).
+  Previously, `()` was used for serialisations that only support
+  protected headers (thus, a single constructor).  This release
+  introduces the new singleton data type `RequiredProtected` to
+  replace the use of `()` for this purpose.  This is a breaking
+  change and some library users will need to update their code.
+
+  The `Protection` type has been renamed to `OptionalProtection`,
+  with the old name retained as a (deprecated) type synonym.
+
+  The `ProtectionIndicator` class has been renamed to
+  `ProtectionSupport`, with the old name retained as a (deprecated)
+  type synonym.
+
+  Added some convenience header and header parameter constructors:
+  `newJWSHeaderProtected`, `newHeaderParamProtected` and
+  `newHeaderParamUnprotected`.
+
 - Generalised the types of `signJWT`, `verifyJWT` and related
   functions to accept custom JWS header types.  Added new type
   synonym `SignedJWTWithHeader h`.  This change could break some

--- a/example/JWS.hs
+++ b/example/JWS.hs
@@ -39,7 +39,7 @@ doJwsSign [jwkFilename, payloadFilename] = do
   payload <- L.readFile payloadFilename
   result <- runJOSE $ do
     h <- makeJWSHeader k
-    signJWS payload [(h :: JWSHeader Protection, k)]
+    signJWS payload [(h :: JWSHeader OptionalProtection, k)]
   case result of
     Left e -> print (e :: Error) >> exitFailure
     Right jws -> L.putStr (encode jws)

--- a/src/Crypto/JOSE/JWE.hs
+++ b/src/Crypto/JOSE/JWE.hs
@@ -82,7 +82,7 @@ data JWEHeader p = JWEHeader
   }
   deriving (Eq, Show)
 
-newJWEHeader :: ProtectionIndicator p => AlgWithParams -> Enc -> JWEHeader p
+newJWEHeader :: (ProtectionSupport p) => AlgWithParams -> Enc -> JWEHeader p
 newJWEHeader alg enc =
   JWEHeader (Just alg) (HeaderParam getProtected enc) z z z z z z z z z z z
   where z = Nothing
@@ -134,7 +134,7 @@ instance FromJSON (JWERecipient a p) where
     <*> o .:? "encrypted_key"
 
 parseRecipient
-  :: (HasParams a, ProtectionIndicator p)
+  :: (HasParams a, ProtectionSupport p)
   => Maybe Object -> Maybe Object -> Value -> Parser (JWERecipient a p)
 parseRecipient hp hu = withObject "JWE Recipient" $ \o -> do
   hr <- o .:? "header"
@@ -153,7 +153,7 @@ data JWE a p = JWE
   , _jweRecipients :: [JWERecipient a p]
   }
 
-instance (HasParams a, ProtectionIndicator p) => FromJSON (JWE a p) where
+instance (HasParams a, ProtectionSupport p) => FromJSON (JWE a p) where
   parseJSON = withObject "JWE JSON Serialization" $ \o -> do
     hpB64 <- o .:? "protected"
     hp <- maybe

--- a/src/Crypto/JWT.hs
+++ b/src/Crypto/JWT.hs
@@ -138,7 +138,7 @@ mkClaims = do
 doJwtSign :: 'JWK' -> 'ClaimsSet' -> IO (Either 'JWTError' 'SignedJWT')
 doJwtSign jwk claims = 'runJOSE' $ do
   alg \<- 'bestJWSAlg' jwk
-  'signClaims' jwk ('newJWSHeader' ((), alg)) claims
+  'signClaims' jwk ('newJWSHeaderProtected' alg) claims
 
 doJwtVerify :: 'JWK' -> 'SignedJWT' -> IO (Either 'JWTError' 'ClaimsSet')
 doJwtVerify jwk jwt = 'runJOSE' $ do
@@ -687,7 +687,7 @@ verifyJWT
     , HasValidationSettings a
     , HasJWSHeader h, HasParams h
     , AsError e, AsJWTError e, MonadError e m
-    , VerificationKeyStore m (h ()) payload k
+    , VerificationKeyStore m (h RequiredProtection) payload k
     , HasClaimsSet payload, FromJSON payload
     )
   => a
@@ -715,7 +715,7 @@ verifyClaims
     , HasValidationSettings a
     , HasJWSHeader h, HasParams h
     , AsError e, AsJWTError e, MonadError e m
-    , VerificationKeyStore m (h ()) ClaimsSet k
+    , VerificationKeyStore m (h RequiredProtection) ClaimsSet k
     )
   => a
   -- ^ Validation settings
@@ -739,7 +739,7 @@ verifyJWTAt
     , HasValidationSettings a
     , HasJWSHeader h, HasParams h
     , AsError e, AsJWTError e, MonadError e m
-    , VerificationKeyStore (ReaderT WrappedUTCTime m) (h ()) payload k
+    , VerificationKeyStore (ReaderT WrappedUTCTime m) (h RequiredProtection) payload k
     , HasClaimsSet payload, FromJSON payload
     )
   => a
@@ -765,7 +765,7 @@ verifyClaimsAt
     , HasValidationSettings a
     , HasJWSHeader h, HasParams h
     , AsError e, AsJWTError e, MonadError e m
-    , VerificationKeyStore (ReaderT WrappedUTCTime m) (h ()) ClaimsSet k
+    , VerificationKeyStore (ReaderT WrappedUTCTime m) (h RequiredProtection) ClaimsSet k
     )
   => a
   -- ^ Validation settings
@@ -793,7 +793,7 @@ signJWT
      , ToJSON payload )
   => JWK
   -- ^ Signing key
-  -> h ()
+  -> h RequiredProtection
   -- ^ JWS Header.  Commonly this will be 'JWSHeader'.  If your application
   -- uses additional header fields, see /Defining additional header parameters/
   -- in "Crypto.JOSE.JWS".
@@ -813,7 +813,7 @@ signClaims
      , HasJWSHeader h, HasParams h )
   => JWK
   -- ^ Signing key
-  -> h ()
+  -> h RequiredProtection
   -- ^ JWS Header.  Commonly this will be 'JWSHeader'.  If your application
   -- uses additional header fields, see /Defining additional header parameters/
   -- in "Crypto.JOSE.JWS".

--- a/test/JWS.hs
+++ b/test/JWS.hs
@@ -108,7 +108,7 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"kid":""}
       s = "{\"protected\":\"eyJraWQiOiIifQ\",\"header\":{\"alg\":\"none\",\"kid\":\"\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader))
         `shouldSatisfy` is _Left
 
   it "rejects reserved crit parameters" $
@@ -116,7 +116,7 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"crit":["kid"],"kid":""}
       s = "{\"protected\":\"eyJjcml0IjpbImtpZCJdLCJraWQiOiIifQ\",\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader))
         `shouldSatisfy` is _Left
 
   it "rejects unknown crit parameters" $
@@ -124,7 +124,7 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"crit":["foo"],"foo":""}
       s = "{\"protected\":\"eyJjcml0IjpbImZvbyJdLCJmb28iOiIifQ\",\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader))
         `shouldSatisfy` is _Left
 
   it "accepts known crit parameter in protected header" $
@@ -132,7 +132,7 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"crit":["foo"],"foo":""}
       s = "{\"protected\":\"eyJjcml0IjpbImZvbyJdLCJmb28iOiIifQ\",\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader'))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader'))
         `shouldSatisfy` is _Right
 
   it "accepts known crit parameter in unprotected header" $
@@ -140,7 +140,7 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"crit":["foo"]}
       s = "{\"protected\":\"eyJjcml0IjpbImZvbyJdfQ\",\"header\":{\"alg\":\"none\",\"foo\":\"\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader'))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader'))
         `shouldSatisfy` is _Right
 
   it "rejects known crit parameter that does not appear in JOSE header" $
@@ -148,14 +148,14 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"crit":["foo"]}
       s = "{\"protected\":\"eyJjcml0IjpbImZvbyJdfQ\",\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader'))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader'))
         `shouldSatisfy` is _Left
 
   it "rejects unprotected crit parameters" $
     let
       s = "{\"header\":{\"alg\":\"none\",\"crit\":[\"foo\"],\"foo\":\"\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader'))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader'))
         `shouldSatisfy` is _Left
 
   it "rejects empty crit parameters" $
@@ -163,7 +163,7 @@ headerSpec = describe "JWS Header" $ do
       -- protected header: {"crit":[]}
       s = "{\"protected\":\"eyJjcml0IjpbXX0\",\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader'))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader'))
         `shouldSatisfy` is _Left
 
   it "parses required protected header when present in protected header" $
@@ -172,28 +172,28 @@ headerSpec = describe "JWS Header" $ do
       s = "{\"protected\":\"eyJjcml0IjpbIm5vbmNlIl0sIm5vbmNlIjoiYm05dVkyVSJ9\""
           <> ",\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection ACMEHeader))
+      (eitherDecode s :: Either String (Signature OptionalProtection ACMEHeader))
         `shouldSatisfy` is _Right
 
   it "rejects required protected header when present in unprotected header" $
     let
       s = "{\"header\":{\"alg\":\"none\"},\"nonce\":\"bm9uY2U\",\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection ACMEHeader))
+      (eitherDecode s :: Either String (Signature OptionalProtection ACMEHeader))
         `shouldSatisfy` is _Left
 
-  it "accepts unprotected \"alg\" param with 'Protection' protection indicator" $
+  it "accepts unprotected \"alg\" param with 'OptionalProtection' protection indicator" $
     let
       s = "{\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature Protection JWSHeader))
+      (eitherDecode s :: Either String (Signature OptionalProtection JWSHeader))
         `shouldSatisfy` is _Right
 
-  it "rejects unprotected \"alg\" param with '()' protection indicator" $
+  it "rejects unprotected \"alg\" param with 'RequiredProtection' protection indicator" $
     let
       s = "{\"header\":{\"alg\":\"none\"},\"signature\":\"\"}"
     in
-      (eitherDecode s :: Either String (Signature () JWSHeader))
+      (eitherDecode s :: Either String (Signature RequiredProtection JWSHeader))
         `shouldSatisfy` is _Left
 
 
@@ -234,8 +234,8 @@ appendixA1Spec = describe "RFC 7515 A.1.  Example JWS using HMAC SHA-256" $ do
     compactJWS = signingInput' <> ".dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
     jws = decodeCompact compactJWS :: Either Error (CompactJWS JWSHeader)
     alg_ = JWA.JWS.HS256
-    h = newJWSHeader ((), alg_)
-        & typ .~ Just (HeaderParam () "JWT")
+    h = newJWSHeaderProtected alg_
+        & typ .~ Just (newHeaderParamProtected "JWT")
     mac = view recons
       [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
       187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
@@ -280,7 +280,7 @@ appendixA2Spec = describe "RFC 7515 A.2. Example JWS using RSASSA-PKCS-v1_5 SHA-
 
   it "prohibits signing with 1024-bit key" $
     fst (withDRG drg (runJOSE $
-      signJWS signingInput' (Identity (newJWSHeader ((), JWA.JWS.RS256), jwkRSA1024))))
+      signJWS signingInput' (Identity (newJWSHeaderProtected JWA.JWS.RS256, jwkRSA1024))))
         `shouldBe` (Left KeySizeTooSmall :: Either Error (CompactJWS JWSHeader))
 
   where
@@ -363,7 +363,7 @@ appendixA5Spec = describe "RFC 7515 A.5.  Example Unsecured JWS" $ do
 
   where
     jws = fst $ withDRG drg $ runJOSE $
-      signJWS examplePayloadBytes (Identity (newJWSHeader ((), JWA.JWS.None), undefined))
+      signJWS examplePayloadBytes (Identity (newJWSHeaderProtected JWA.JWS.None, undefined))
       :: Either Error (CompactJWS JWSHeader)
     exampleJWS = "eyJhbGciOiJub25lIn0\
       \.\

--- a/test/JWT.hs
+++ b/test/JWT.hs
@@ -101,7 +101,7 @@ spec = do
         valConf = defaultJWTValidationSettings (const True)
       k <- genJWK $ RSAGenParam 256
       res <- runJOSE $ do
-        token <- signClaims k (newJWSHeader ((), RS512)) claims
+        token <- signClaims k (newJWSHeaderProtected RS512) claims
         token' <- decodeCompact . encodeCompact $ token
         liftIO $ token' `shouldBe` token
         claims' <- verifyClaims valConf k token'
@@ -114,7 +114,7 @@ spec = do
         now = utcTime "2010-01-01 00:00:00"
       k <- genJWK $ RSAGenParam 256
       res <- runJOSE $ do
-        token <- signJWT k (newJWSHeader ((), RS512)) super
+        token <- signJWT k (newJWSHeaderProtected RS512) super
         token' <- decodeCompact . encodeCompact $ token
         liftIO $ token' `shouldBe` token
         claims <- runReaderT (verifyJWT valConf k token') now

--- a/test/Perf.hs
+++ b/test/Perf.hs
@@ -17,7 +17,7 @@ Related: https://github.com/frasertweedale/hs-jose/pull/103
 import Control.Lens ((^?), _Just)
 import Control.Monad.Except (ExceptT, runExceptT)
 import Crypto.JOSE.JWK.Store (VerificationKeyStore (getVerificationKeys))
-import Crypto.JWT (CompactJWS, HasX5c (x5c), JWSHeader, JWTError, decodeCompact, fromX509Certificate, param, verifyJWS')
+import Crypto.JWT (CompactJWS, HasX5c (x5c), JWSHeader, JWTError, RequiredProtection, decodeCompact, fromX509Certificate, param, verifyJWS')
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -26,7 +26,7 @@ import System.Exit (die)
 
 data Store = Store
 
-instance VerificationKeyStore (ExceptT JWTError IO) (JWSHeader ()) B.ByteString Store where
+instance VerificationKeyStore (ExceptT JWTError IO) (JWSHeader RequiredProtection) B.ByteString Store where
   getVerificationKeys header _ _ = do
     let Just (x :| _) = header ^? x5c . _Just . param
     res <- fromX509Certificate x


### PR DESCRIPTION
Changed the header protection data types for better ergonomics ([#125](https://github.com/frasertweedale/hs-jose/issues/125)). Previously, `()` was used for serialisations that only support protected headers (thus, a single constructor).  This release introduces the new single-constructor data type `ProtectedOnly` to replace the use of `()` for this purpose.  This is a breaking change and some library users will need to update their code.

The `Protection` type has been renamed to `ProtectionOptional`, with the old name retained as a (deprecated) type synonym.

The `ProtectionIndicator` class has been renamed to `ProtectionOptionality`, with the old name retained as a (deprecated) type synonym.

Added some convenience header and header parameter constructors: `newJWSHeaderProtected`, `newHeaderParamProtected` and `newHeaderParamUnprotected`.

Fixes: https://github.com/frasertweedale/hs-jose/issues/125