### PR TITLE
Update to crypton >= 1.1.0 and ram instead of memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Version 0.13 (2026-06-06)
+
+- Update to *crypton >= 1.1.0* and *ram*.  There are no
+  functional changes in this release.  Until the release
+  of 0.14, any behavioural changes (bug fixes, etc) will
+  be released to both the 0.13 and 0.12 series.
+
 ## Version 0.12 (2025-08-18)
 
 - GHC 9.6 is now the earliest supported version.

--- a/jose.cabal
+++ b/jose.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                jose
-version:             0.12
+version:             0.13
 synopsis:
   JSON Object Signing and Encryption (JOSE) and JSON Web Token (JWT) library
 description:
@@ -99,8 +99,8 @@ library
     , base64-bytestring >= 1.2.1.0 && < 1.3
     , concise >= 0.1
     , containers >= 0.5.8
-    , crypton >= 0.31
-    , memory >= 0.7
+    , crypton >= 1.1.0
+    , ram < 0.22
     , monad-time >= 0.4
     , template-haskell >= 2.12
     , text >= 1.1

--- a/jose.cabal
+++ b/jose.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                jose
-version:             0.12
+version:             0.12.0.1
 synopsis:
   JSON Object Signing and Encryption (JOSE) and JSON Web Token (JWT) library
 description:
@@ -99,7 +99,7 @@ library
     , base64-bytestring >= 1.2.1.0 && < 1.3
     , concise >= 0.1
     , containers >= 0.5.8
-    , crypton >= 0.31
+    , crypton >= 0.31 && < 1.1
     , memory >= 0.7
     , monad-time >= 0.4
     , template-haskell >= 2.12

--- a/jose.cabal
+++ b/jose.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                jose
-version:             0.12.0.1
+version:             0.13
 synopsis:
   JSON Object Signing and Encryption (JOSE) and JSON Web Token (JWT) library
 description:
@@ -99,8 +99,8 @@ library
     , base64-bytestring >= 1.2.1.0 && < 1.3
     , concise >= 0.1
     , containers >= 0.5.8
-    , crypton >= 0.31 && < 1.1
-    , memory >= 0.7
+    , crypton >= 1.1.0
+    , ram >= 0.19
     , monad-time >= 0.4
     , template-haskell >= 2.12
     , text >= 1.1


### PR DESCRIPTION
The latest crypton (1.1.0) has now switched to ram instead of memory. 